### PR TITLE
Fix port variable for 2.4 and 2.6 configs

### DIFF
--- a/templates/mongodb-2.4.conf.erb
+++ b/templates/mongodb-2.4.conf.erb
@@ -7,7 +7,7 @@ logpath=<%= @logpath %>
 fork = true
 
 bind_ip = <%= @bind_ip %>
-port = <%= @port %>
+port = <%= @net_port %>
 
 dbpath=<%= @dbpath %>
 

--- a/templates/mongodb-2.6.conf.erb
+++ b/templates/mongodb-2.6.conf.erb
@@ -2,7 +2,7 @@
 ### Basic Defaults
 ##
 bind_ip = <%= @bind_ip %>
-port = <%= @port %>
+port = <%= @net_port %>
 fork = true
 pidfilepath = <%= @pidfilepath %>
 logpath = <%= @logpath %>


### PR DESCRIPTION
Port variable for configs 2.4 and 2.6 are trying to resolve @port, but there's not such variable. It seems to have been changed to net_port.