### PR TITLE
Software Collection and basic user management

### DIFF
--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -20,6 +20,8 @@ class mongodb::auth (
   $root_dbname    = 'admin',
   $users          = {},
 ) {
+  require mongodb
+
   # Create mandatory root user with empty rc
   exec { 'mongo-rc-root-init':
     path    => [ '/bin', '/usr/bin', ],

--- a/manifests/auth.pp
+++ b/manifests/auth.pp
@@ -1,0 +1,41 @@
+# Class: mongodb::auth
+#
+# Allow basic management of users and roles
+# by creating at least a root user
+# and any extra users defined from a hash
+# For instance:
+#
+# include mongodb::auth
+# 
+# class { 'mongodb::auth'
+#   root_password: 'secret',
+#   users: { foo: { password: 'secret', roles: '[ "readWrite" ]', dbname: 'foodata' } }
+#
+# The unix root user will be provided with a ~/.mongorc.js script
+# which is required to support updating Mongo DB root password
+#
+class mongodb::auth (
+  $root_password,
+  $root_username  = 'root',
+  $root_dbname    = 'admin',
+  $users          = {},
+) {
+  # Create mandatory root user with empty rc
+  exec { 'mongo-rc-root-init':
+    path    => [ '/bin', '/usr/bin', ],
+    command => "echo '' > '/root/.mongorc.js'",
+    unless  => "test -f '/root/.mongorc.js'",
+  } ->
+
+  mongodb::auth::user { "${root_username}":
+    password  => "${root_password}",
+    roles     => '[ "root" ]',
+    login_username => '',
+    login_password => '',
+    local_username => 'root',
+    local_userhome => '/root',
+  }
+
+  # Create optional users
+  create_resources(mongodb::auth::user, $users)
+}

--- a/manifests/auth/user.pp
+++ b/manifests/auth/user.pp
@@ -28,7 +28,14 @@ define mongodb::auth::user (
   $local_username	= false,
   $local_userhome = false,
 ) {
+  require mongodb
   include mongodb::auth
+
+  # Make sure root user is created first
+  # Just in case the resource is called directly
+  if ($username != $mongodb::auth::root_username) {
+    Mongodb::Auth::User["$mongodb::auth::root_username"] -> Exec["user-${username}"]
+  }
 
   $net_port = $mongodb::net_port
 

--- a/manifests/auth/user.pp
+++ b/manifests/auth/user.pp
@@ -85,10 +85,13 @@ EOF
       }
 
       if ($local_username) {
-        file { "mongo-rc-${local_username}":
+        file { "mongo-rc-${username}":
           path      => "${rc_path}",
           content   => template('mongodb/auth/rc.js.erb'),
-          owner     => "${local_username}",
+          owner     => "${local_username}" ? {
+            true		=> "${username}",
+            default	=> "${local_username}",
+          },
           mode      => '0600',
           require   => Exec["user-${username}"],
           show_diff => false,

--- a/manifests/auth/user.pp
+++ b/manifests/auth/user.pp
@@ -1,0 +1,95 @@
+# Define: mongodb::auth::user
+#
+# Example Usage:
+#   mongodb::auth::user { foo:
+#     password => 'secret',
+#     dbname   => 'foodata',
+#     roles:   => '[ "readWrite" ]',
+#   }
+#
+# REM: roles need to be passed as a valid JSON string
+# For more info about the syntax:
+#   https://docs.mongodb.com/manual/reference/command/createRole/#roles
+#
+# In case local_username is set, the corresponding user
+# will be provided with a ~/.mongorc.js script to automate
+# its login when starting the Mongo shell
+# 
+define mongodb::auth::user (
+  $password,
+  $username = "$name",
+  $dbname   = 'admin',
+  $ensure   = 'present',
+  $roles		= '[ "readWriteAnyDatabase" ]',
+  $scl_name = "$mongodb::scl_name",
+  $login_username = "$mongodb::auth::root_username",
+  $login_password = "$mongodb::auth::root_password",
+  $login_dbname = "$mongodb::auth::root_dbname",
+  $local_username	= false,
+  $local_userhome = false,
+) {
+  include mongodb::auth
+
+  $net_port = $mongodb::net_port
+
+  # Construct the correct command line to call Mongo shell
+  if ($scl_name) {
+    $mongo_cmd = "scl enable ${scl_name} -- mongo --quiet --port $net_port"
+  } else {
+    $mongo_cmd = "mongo --quiet --port $net_port"
+  }
+
+  # Construct login arguments if relevant
+  if ($login_username) { 
+    $mongo_user_arg = " -u '${login_username}'"
+  }
+  if ($login_password) {
+    $mongo_pwd_arg = " -p '${login_password}'"
+  }
+  if ($login_dbname) {
+    $mongo_db_arg = "'${login_dbname}'"
+  }
+
+  Exec {
+    path => [ '/bin', '/sbin', '/usr/bin', '/usr/sbin', '/usr/local/bin', '/usr/local/sbin', ],
+  }
+
+  case $ensure {
+    'absent': {
+      # FIXME
+    }
+    'present': {
+      $script = template('mongodb/auth/user.js.erb')
+
+		  exec { "user-${username}":
+		    provider => 'shell',
+		    command => "{ cat /root/.mongorc.js; cat <<EOF
+${script}
+EOF
+} | ${mongo_cmd} ${mongo_db_arg}",
+        unless  => "${mongo_cmd} -u ${username} -p ${password} ${dbname}",
+        logoutput => on_failure,
+		  }
+
+      if ($local_userhome) {
+        $rc_path = "$local_userhome/.mongorc.js"
+      } else {
+        $rc_path = "/home/${local_username}/.mongorc.js"
+      }
+
+      if ($local_username) {
+        file { "mongo-rc-${local_username}":
+          path      => "${rc_path}",
+          content   => template('mongodb/auth/rc.js.erb'),
+          owner     => "${local_username}",
+          mode      => '0600',
+          require   => Exec["user-${username}"],
+          show_diff => false,
+        }
+      }
+		}
+    default: {
+      notice('Unknown value for ensure')
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -58,6 +58,7 @@ class mongodb (
   $replication_oplogsizemb = undef,
   $replication_replsetname = undef,
   $scl_name       = $::mongodb::params::scl_name,
+  $tools          = false, # do not install tools by default
 ) inherits ::mongodb::params {
 
   # Main package and service
@@ -79,5 +80,23 @@ class mongodb (
     require => Package[$package],
   }
 
-}
+  if ($tools) {
+    package { $package_tools: ensure => 'installed' } ->
 
+    file { 'mongotools-wrapper':
+      path    => '/usr/local/bin/mongotools',
+      content => template('mongodb/mongotools.erb'),
+      mode    => '0755',
+    } ->
+
+    file { 'mongodump-lnk':
+      path    => '/usr/local/bin/mongodump',
+      ensure  => './mongotools',
+    } ->
+
+    file { 'mongorestore-lnk':
+      path    => '/usr/local/bin/mongorestore',
+      ensure  => './mongotools',
+    }
+  }
+}

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -19,12 +19,13 @@ class mongodb (
   $conffile       = $::mongodb::params::conffile,
   $package        = $::mongodb::params::package,
   $template       = $::mongodb::params::template,
+  $runpath        = $::mongodb::params::runpath,
   $pidfilepath    = $::mongodb::params::pidfilepath,
   # Just in case you wonder : quoted 'false' is for true/false text to be
   # set in the configuration file.
   $logpath        = $::mongodb::params::logpath,
   $bind_ip        = '127.0.0.1',
-  $dbpath         = '/var/lib/mongodb',
+  $dbpath         = $::mongodb::params::dbpath,
   $auth           = undef,
   $verbose        = undef, # old
   $verbosity      = undef, # new yaml
@@ -56,7 +57,7 @@ class mongodb (
   $security_keyfile        = undef,
   $replication_oplogsizemb = undef,
   $replication_replsetname = undef,
-  
+  $scl_name       = $::mongodb::params::scl_name,
 ) inherits ::mongodb::params {
 
   # Main package and service

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -60,9 +60,14 @@ class mongodb::params (
   $pidfilepath = "${runpath}/${progname}.pid"
   $logpath = "/var${scl_spath}/log/mongodb/${progname}.log"
 
-  # package
+  # package(s)
   case $::operatingsystem {
     'Gentoo': { $package = 'dev-db/mongodb' }
     default:  { $package = [ "${scl_prefix}mongodb", "${scl_prefix}mongodb-server" ] }
+  }
+
+  case $::operatingsystem {
+    'Gentoo': { $package_tools = 'dev-db/mongo-tools' }
+    default:  { $package_tools = "${scl_prefix}mongo-tools" }
   }
 }

--- a/templates/auth/rc.js.erb
+++ b/templates/auth/rc.js.erb
@@ -1,2 +1,1 @@
-db = connect("localhost:<%= @net_port %>/<%= @dbname %>")
-db.getSiblingDB("<%= @dbname %>").auth("<%= @username %>", "<%= @password %>")
+db = connect("mongodb://<%= @username %>:<%= @password %>@localhost:<%= @net_port %>/<%= @dbname %>")

--- a/templates/auth/rc.js.erb
+++ b/templates/auth/rc.js.erb
@@ -1,0 +1,2 @@
+db = connect("localhost:<%= @net_port %>/<%= @dbname %>")
+db.getSiblingDB("<%= @dbname %>").auth("<%= @username %>", "<%= @password %>")

--- a/templates/auth/user.js.erb
+++ b/templates/auth/user.js.erb
@@ -1,0 +1,119 @@
+// Initialize variables with arguments passed by eval option
+// or defined using ERB template
+
+var _dbnane, _username, _password, _roles
+
+if (typeof dbname == "string") {
+  _dbname = dbname
+} else {
+  _dbname = "<%= @dbname %>"
+}
+if (typeof username == "string") {
+  _username = username
+} else {
+  _username = "<%= @username %>"
+}
+if (typeof password == "string") {
+  _password = password
+} else {
+  _password = "<%= @password %>"
+}
+if (typeof roles == "object") {
+  _roles = roles
+} else {
+  // Via string to avoid syntax error
+  _roles = JSON.parse('<%= @roles %>')
+}
+
+// Exit with error in case of wrong parameters
+if (typeof _dbname != "string") {
+  print("Parameter dbname type is " + typeof _dbname)
+  quit(1)
+}
+if (typeof _username != "string") {
+  print("Parameter username type is " + typeof _username)
+  quit(1)
+}
+if (typeof _password != "string") {
+  print("Parameter password type is " + typeof _password)
+  quit(1)
+}
+if (typeof _roles != "object") {
+  print("Parameter roles type is " + typeof _roles)
+  quit(1)
+}
+
+// Open the selected DB
+print("Opening DB \'" + _dbname + "\'")
+db = db.getSiblingDB(_dbname);
+
+// Expand roles to make the default db explicit
+// and ease later comparison
+var _xroles = []
+for (var i in _roles) {
+  if (typeof _roles[i] == 'string') {
+    _xroles.push({ role: _roles[i], db: _dbname })
+  } else {
+    _xroles.push(_roles[i])
+  }
+}
+
+// Create the initial root user if required
+if (_xroles[0]['role'] == 'root' && db.serverStatus().code == 13) {
+  print("User \'" + _username + "\' needs to be created")
+  db.createUser({
+    user: _username,
+    pwd: _password,
+    roles: _roles
+  })
+} else {
+  // Create custom roles if not existing
+  // They will inherit from readWrite by default
+  // and SHOULD be updated externaly later
+  for (var i in _xroles) {
+    if (db.getRole(_xroles[i]['role']) === null) {
+      print("Role \'" + _xroles[i]['role'] + "\' was not found")
+      db.createRole({
+        role: _xroles[i]['role'],
+        privileges: [],
+        roles: [ "readWrite" ]
+      })
+    } else {
+      print("Role \'" + _xroles[i]['role'] + "\' already exists")
+    }
+  }
+
+  // Extract user info if existing
+  var user = db.getUser(_username)
+
+  // Create the user if not existing
+  if (user == null) {
+    print("User \'" + _username + "\' was not found")
+    db.createUser({
+      user: _username,
+      pwd: _password,
+      roles: _roles
+    })
+  } else {
+    print("User \'" + _username + "\' already exists")
+
+    // Update the _roles if not matching
+    // TODO: sort _roles before comparison
+    if (JSON.stringify(user.roles) != JSON.stringify(_xroles)) {
+      print("roles need to be updated for user \'" + _username + "\'")
+      db.updateUser(
+        _username,
+        { roles: _xroles }
+      )
+    }
+
+    // Update the _password if not matching
+    if (db.auth(_username, _password) != 1) {
+      print("password needs to be updated for user \'" + _username + "\'")
+      db.updateUser(
+        _username,
+        { pwd: _password }
+      )
+    }
+  }
+}

--- a/templates/auth/user.js.erb
+++ b/templates/auth/user.js.erb
@@ -44,7 +44,7 @@ if (typeof _roles != "object") {
 }
 
 // Open the selected DB
-print("Opening DB \'" + _dbname + "\'")
+print("Using DB \'" + _dbname + "\'")
 db = db.getSiblingDB(_dbname);
 
 // Expand roles to make the default db explicit
@@ -71,9 +71,15 @@ if (_xroles[0]['role'] == 'root' && db.serverStatus().code == 13) {
   // They will inherit from readWrite by default
   // and SHOULD be updated externaly later
   for (var i in _xroles) {
-    if (db.getRole(_xroles[i]['role']) === null) {
+  	if (_xroles[i]['db'] != _dbname ) {
+	  print("Using DB \'" + _xroles[i]['db'] + "\' for role management")
+	  _dbrole = db.getSiblingDB(_xroles[i]['db'])
+    } else {
+      _dbrole = db
+    }
+    if (_dbrole.getRole(_xroles[i]['role']) === null) {
       print("Role \'" + _xroles[i]['role'] + "\' was not found")
-      db.createRole({
+      _dbrole.createRole({
         role: _xroles[i]['role'],
         privileges: [],
         roles: [ "readWrite" ]

--- a/templates/mongod-2.6.conf.erb
+++ b/templates/mongod-2.6.conf.erb
@@ -1,0 +1,338 @@
+##
+### Basic Defaults
+##
+
+# Comma separated list of ip addresses to listen on (all local ips by default)
+bind_ip = <%= @bind_ip %>
+
+# Specify port number (27017 by default)
+port = <%= @net_port %>
+
+# Fork server process (false by default)
+fork = true
+
+# Full path to pidfile (if not set, no pidfile is created)
+pidfilepath = <%= @pidfilepath %>
+
+# Log file to send write to instead of stdout - has to be a file, not directory
+logpath = <%= @logpath %>
+
+# Alternative directory for UNIX domain sockets (defaults to /tmp)
+unixSocketPrefix = <%= @runpath %>
+
+# Directory for datafiles (defaults to /data/db/)
+dbpath = <%= @dbpath %>
+
+# Enable/Disable journaling (journaling is on by default for 64 bit)
+journal = true
+#nojournal = true
+
+
+
+##
+### General options
+##
+
+# Be more verbose (include multiple times for more verbosity e.g. -vvvvv) (v by default)
+<% if @verbose -%>
+verbose = <%= @verbose %>
+<% else -%>
+#verbose = v
+<% end -%>
+
+# Max number of simultaneous connections (1000000 by default)
+#maxConns = 1000000              
+
+# Log to system's syslog facility instead of file or stdout (false by default)
+#syslog = true
+
+# Syslog facility used for monogdb syslog message (user by defautl)
+#syslogFacility = user
+
+# Append to logpath instead of over-writing (false by default)
+#logappend = true
+
+# Desired format for timestamps in log messages (One of ctime, iso8601-utc or iso8601-local) (iso8601-local by default)
+#timeStampFormat = arg  
+
+# Private key for cluster authentication
+<% if @keyfile -%>
+keyFile = <%= @keyfile %>
+<% else -%>
+#keyFile = arg
+<% end -%>
+
+# Set a configurable parameter
+#setParameter = arg
+
+# Enable http interface (false by default)
+#httpinterface = true
+
+# Authentication mode used for cluster authentication. Alternatives are (keyFile|sendKeyFile|sendX509|x509) (keyFile by default)
+#clusterAuthMode = arg
+
+# Disable listening on unix sockets (false by default)
+#nounixsocket = true
+
+# Run with/without security (without by default)
+<% if @auth == 'true' -%>
+auth = true
+<% else -%>
+#auth = true
+<% end -%>
+#noauth = true
+
+# Enable IPv6 support (disabled by default)
+#ipv6 = true
+
+# Allow JSONP access via http (has security implications) (false by default)
+#jsonp = true
+
+# Turn on simple rest api (false by default)
+<% if @rest -%>
+rest = <%= @rest %>
+<% else -%>
+#rest = true
+<% end -%>
+
+# Value of slow for profile and console log (100 by default)
+#slowms = 100
+
+# 0=off 1=slow, 2=all (0 by default)
+#profile = 0
+
+# Periodically show cpu and iowait utilization (false by default)
+#cpu = true
+
+# Print some diagnostic system information (false by default)
+#sysinfo = true
+
+# Each database will be stored in a separate directory (false by default)
+#directoryperdb = true
+
+# Don't retry any index builds that were interrupted by shutdown (false by default)
+#noIndexBuildRetry = true
+
+# Disable data file preallocation - will often hurt performance (false by default)
+#noprealloc = true
+
+# .ns file size (in MB) for new databases (16 MB by default)
+#nssize = 16
+
+# Limits each database to a certain number of files (8 default)
+<% if @quota -%>
+quota = <%= @quota %>
+<% else -%>
+#quota
+<% end -%>
+
+# Number of files allowed per db, implies --quota (8 by default)
+#quotaFiles = 8
+
+# Use a smaller default file size (false by default)
+<% if @smallfiles -%>
+smallfiles = <%= @smallfiles %>
+<% else -%>
+#smallfiles = true
+<% end -%>
+
+# Seconds between disk syncs (0=never, but not recommended) (60 by default)
+#syncdelay = 60
+
+# Upgrade db if needed (false by default)
+#upgrade = true
+
+# Run repair on all dbs (false by default)
+#repair = true
+
+# Root directory for repair files (defaults to dbpath)
+#repairpath = arg
+
+# Disable scripting engine (false by default)
+#noscripting = true
+
+# Do not allow table scans (false by default)
+#notablescan = true
+
+# Journal diagnostic options (0 by default)
+#journalOptions = 0
+
+# How often to group/batch commit (ms) (100 or 30 by default)
+#journalCommitInterval = 100 
+
+# Inspect all client data for validity on receipt (useful for
+# developing drivers)
+<% if @objcheck -%>
+objcheck = <%= @objcheck %>
+<% else -%>
+#objcheck = true
+<% end -%>
+
+
+
+##
+### Replication options
+##
+
+# Size to use (in MB) for replication op log (default 5% of disk space - i.e. large is good)
+<% if @oplogsize -%>
+oplogSize = <%= @oplogsize %>
+<% else -%>
+#oplogSize = arg
+<% end -%>
+
+# Set oplogging level where n is
+#   0=off (default)
+#   1=W
+#   2=R
+#   3=both
+#   7=W+some reads
+<% if @oplog -%>
+oplog = <%= @oplog %>
+<% else -%>
+#oplog = 0
+<% end -%>
+
+# Size limit for in-memory storage of op ids.
+<% if @opidmem -%>
+opIdMem = <%= @opidmem %>
+<% else -%>
+#opIdMem = <bytes>
+<% end -%>
+
+
+
+##
+### Master/slave options (old; use replica sets instead)
+##
+
+# Master mode
+<% if @master -%>
+master = <%= @master %>
+<% else -%>
+#master = true
+<% end -%>
+
+# Slave mode
+<% if @slave -%>
+slave = <%= @slave %>
+<% else -%>
+#slave = true
+<% end -%>
+
+# When slave: specify master as <server:port>
+<% if @source -%>
+source = <%= @source %>
+<% else -%>
+#source = arg
+<% end -%>
+
+# When slave: specify a single database to replicate
+<% if @slave and @only -%>
+only = <%= @only %>
+<% else -%>
+#only = arg
+<% end -%>
+
+# Specify delay (in seconds) to be used when applying master ops to slave
+#slavedelay = arg
+
+# Automatically resync if slave data is stale
+<% if @autoresync -%>
+autoresync = <%= @autoresync %>
+<% else -%>
+#autoresync = true
+<% end -%>
+
+
+
+##
+### Replica set options
+##
+
+# Arg is <setname>[/<optionalseedhostlist>]
+<% if @replset -%>
+replSet = <%= @replset %>
+<% else -%>
+#replSet = arg
+<% end -%>
+
+# Specify index prefetching behavior (if secondary) [none|_id_only|all] (all by default)
+#replIndexPrefetch = all
+
+# Address of a server to pair with
+<% if @pairwith -%>
+pairwith = <%= @pairwith %>
+<% else -%>
+#pairwith = <server:port>
+<% end -%>
+
+# Address of arbiter server
+<% if @arbiter -%>
+arbiter = <%= @arbiter %>
+<% else -%>
+#arbiter = <server:port>
+<% end -%>
+
+
+
+##
+### Sharding options
+##
+
+# Declare this is a config db of a cluster (default port 27019; default dir /data/configdb) (false by default)
+#configsvr = true
+
+# Declare this is a shard db of a cluster (default port 27018)  (false by default)
+#shardsvr = true
+
+
+
+##
+### SSL options
+##
+
+# Use ssl on configured ports
+#sslOnNormalPorts = true
+
+# Set the SSL operation mode (disabled|allowSSL|preferSSL|requireSSL)
+# sslMode = arg
+
+# PEM file for ssl
+#sslPEMKeyFile = arg
+
+# PEM file password
+#sslPEMKeyPassword = arg
+
+# Key file for internal SSL authentication
+#sslClusterFile = arg
+
+# Internal authentication key file password
+#sslClusterPassword = arg
+
+# Certificate Authority file for SSL
+#sslCAFile = arg
+
+# Certificate Revocation List file for SSL
+#sslCRLFile = arg
+
+# Allow client to connect without presenting a certificate
+#sslWeakCertificateValidation = true
+
+# Allow server certificates to provide non-matching hostnames
+#sslAllowInvalidHostnames = true
+
+# Allow connections to servers with invalid certificates
+#sslAllowInvalidCertificates = true
+
+# Activate FIPS 140-2 mode at startup
+#sslFIPSMode = true
+
+<% if !@extra_options.empty? -%>
+
+
+# Extra options
+<% @extra_options.sort_by {|key, value| key}.each do |key,value| -%>
+<%= key %> = <%= value %>
+<% end -%>
+<% end -%>

--- a/templates/mongod-2.6.conf.orig
+++ b/templates/mongod-2.6.conf.orig
@@ -1,0 +1,237 @@
+##
+### Basic Defaults
+##
+
+# Comma separated list of ip addresses to listen on (all local ips by default)
+bind_ip = 127.0.0.1
+
+# Specify port number (27017 by default)
+#port = 27017
+
+# Fork server process (false by default)
+fork = true
+
+# Full path to pidfile (if not set, no pidfile is created)
+pidfilepath = /var/run/mongodb/mongod.pid
+
+# Log file to send write to instead of stdout - has to be a file, not directory
+logpath = /var/log/mongodb/mongod.log
+
+# Alternative directory for UNIX domain sockets (defaults to /tmp)
+unixSocketPrefix = /var/run/mongodb
+
+# Directory for datafiles (defaults to /data/db/)
+dbpath = /var/lib/mongodb
+
+# Enable/Disable journaling (journaling is on by default for 64 bit)
+#journal = true
+#nojournal = true
+
+
+
+##
+### General options
+##
+
+# Be more verbose (include multiple times for more verbosity e.g. -vvvvv) (v by default)
+#verbose = v
+
+# Max number of simultaneous connections (1000000 by default)
+#maxConns = 1000000              
+
+# Log to system's syslog facility instead of file or stdout (false by default)
+#syslog = true
+
+# Syslog facility used for monogdb syslog message (user by defautl)
+#syslogFacility = user
+
+# Append to logpath instead of over-writing (false by default)
+#logappend = true
+
+# Desired format for timestamps in log messages (One of ctime, iso8601-utc or iso8601-local) (iso8601-local by default)
+#timeStampFormat = arg  
+
+# Private key for cluster authentication
+#keyFile = arg
+
+# Set a configurable parameter
+#setParameter = arg
+
+# Enable http interface (false by default)
+#httpinterface = true
+
+# Authentication mode used for cluster authentication. Alternatives are (keyFile|sendKeyFile|sendX509|x509) (keyFile by default)
+#clusterAuthMode = arg
+
+# Disable listening on unix sockets (false by default)
+#nounixsocket = true
+
+# Run with/without security (without by default)
+#auth = true
+#noauth = true
+
+# Enable IPv6 support (disabled by default)
+#ipv6 = true
+
+# Allow JSONP access via http (has security implications) (false by default)
+#jsonp = true
+
+# Turn on simple rest api (false by default)
+#rest = true
+
+# Value of slow for profile and console log (100 by default)
+#slowms = 100
+
+# 0=off 1=slow, 2=all (0 by default)
+#profile = 0
+
+# Periodically show cpu and iowait utilization (false by default)
+#cpu = true
+
+# Print some diagnostic system information (false by default)
+#sysinfo = true
+
+# Each database will be stored in a separate directory (false by default)
+#directoryperdb = true
+
+# Don't retry any index builds that were interrupted by shutdown (false by default)
+#noIndexBuildRetry = true
+
+# Disable data file preallocation - will often hurt performance (false by default)
+#noprealloc = true
+
+# .ns file size (in MB) for new databases (16 MB by default)
+#nssize = 16
+
+# Limits each database to a certain number of files (8 default)
+#quota
+
+# Number of files allowed per db, implies --quota (8 by default)
+#quotaFiles = 8
+
+# Use a smaller default file size (false by default)
+#smallfiles = true
+
+# Seconds between disk syncs (0=never, but not recommended) (60 by default)
+#syncdelay = 60
+
+# Upgrade db if needed (false by default)
+#upgrade = true
+
+# Run repair on all dbs (false by default)
+#repair = true
+
+# Root directory for repair files (defaults to dbpath)
+#repairpath = arg
+
+# Disable scripting engine (false by default)
+#noscripting = true
+
+# Do not allow table scans (false by default)
+#notablescan = true
+
+# Journal diagnostic options (0 by default)
+#journalOptions = 0
+
+# How often to group/batch commit (ms) (100 or 30 by default)
+#journalCommitInterval = 100 
+
+
+
+##
+### Replication options
+##
+
+# Size to use (in MB) for replication op log (default 5% of disk space - i.e. large is good)
+#oplogSize = arg
+
+
+
+##
+### Master/slave options (old; use replica sets instead)
+##
+
+# Master mode
+#master = true
+
+# Slave mode
+#slave = true
+
+# When slave: specify master as <server:port>
+#source = arg
+
+# When slave: specify a single database to replicate
+#only = arg
+
+# Specify delay (in seconds) to be used when applying master ops to slave
+#slavedelay = arg
+
+# Automatically resync if slave data is stale
+#autoresync = true
+
+
+
+##
+### Replica set options
+##
+
+# Arg is <setname>[/<optionalseedhostlist>]
+#replSet = arg
+
+# Specify index prefetching behavior (if secondary) [none|_id_only|all] (all by default)
+#replIndexPrefetch = all
+
+
+
+##
+### Sharding options
+##
+
+# Declare this is a config db of a cluster (default port 27019; default dir /data/configdb) (false by default)
+#configsvr = true
+
+# Declare this is a shard db of a cluster (default port 27018)  (false by default)
+#shardsvr = true
+
+
+
+##
+### SSL options
+##
+
+# Use ssl on configured ports
+#sslOnNormalPorts = true
+
+# Set the SSL operation mode (disabled|allowSSL|preferSSL|requireSSL)
+# sslMode = arg
+
+# PEM file for ssl
+#sslPEMKeyFile = arg
+
+# PEM file password
+#sslPEMKeyPassword = arg
+
+# Key file for internal SSL authentication
+#sslClusterFile = arg
+
+# Internal authentication key file password
+#sslClusterPassword = arg
+
+# Certificate Authority file for SSL
+#sslCAFile = arg
+
+# Certificate Revocation List file for SSL
+#sslCRLFile = arg
+
+# Allow client to connect without presenting a certificate
+#sslWeakCertificateValidation = true
+
+# Allow server certificates to provide non-matching hostnames
+#sslAllowInvalidHostnames = true
+
+# Allow connections to servers with invalid certificates
+#sslAllowInvalidCertificates = true
+
+# Activate FIPS 140-2 mode at startup
+#sslFIPSMode = true
+

--- a/templates/mongod-3.0.conf.erb
+++ b/templates/mongod-3.0.conf.erb
@@ -19,7 +19,7 @@ net:
   bindIp: <%= @net_bindip %>
   port: <%= @net_port %>
   unixDomainSocket:
-    pathPrefix: '/var/run/mongodb'
+    pathPrefix: '<%= @runpath %>'
 <% if @security_keyfile or @authorization -%>
 security:
   <%- if @authorization -%>

--- a/templates/mongod-3.4.conf.erb
+++ b/templates/mongod-3.4.conf.erb
@@ -1,0 +1,154 @@
+##
+## For list of options visit:
+## https://docs.mongodb.org/manual/reference/configuration-options/
+##
+
+# systemLog Options - How to do logging
+systemLog:
+  # The default log message verbosity level for components (0-5)
+  <%- if @systemlog_verbosity -%>
+  verbosity: <%= @systemlog_verbosity %>
+  <%- else -%>
+  verbosity: 0
+  <%- end -%>
+
+  # The destination to which MongoDB sends all log output (file|syslog, if not specifed to STDOUT)
+  destination: file
+
+  # Log file to send write to instead of stdout - has to be a file, not directory
+  path: <%= @logpath %>
+
+  # Append to logpath instead of over-writing (false by default)
+  logAppend: true
+
+  # Set the log rotation behavior (rename|reopen, rename by default)
+  logRotate: reopen
+
+
+# processManagement Options - How the process runs
+processManagement:
+  # Fork server process (false by default)
+  fork: true
+
+  # Full path to pidfile (if not set, no pidfile is created)
+  pidFilePath: <%= @pidfilepath %>
+
+
+# net Options - Network interfaces settings
+net:
+  # Specify port number (27017 by default)
+  port: <%= @net_port %>
+
+  # Comma separated list of ip addresses to listen on (all local ips by default)
+  bindIp: <%= @net_bindip %>
+
+  # Enable IPv6 support (disabled by default)
+  ipv6: false
+
+  unixDomainSocket:
+    # Enable/disable listening on the UNIX domain socket (true by default)
+    enabled: true
+
+    # Alternative directory for UNIX domain sockets (defaults to /tmp)
+    pathPrefix: <%= @runpath %>
+
+  #ssl:
+    # Set the SSL operation mode (disabled|allowSSL|preferSSL|requireSSL)
+    #mode: <string>
+
+    # PEM file for ssl
+    #PEMKeyFile: <string>
+
+    # Certificate Authority file for SSL
+    #CAFile: <string>
+
+
+# storage Options - How and Where to store data
+storage:
+  # Directory for datafiles (defaults to /data/db/)
+  dbPath: <%= @storage_dbpath %>
+
+  #journal:
+    # Enable/Disable journaling (journaling is on by default for 64 bit)
+    #enabled: true
+
+  # The storage engine for the mongod database (mmapv1|wiredTiger, wiredTiger by default
+  # - works for 64 bit only)
+  # Also possible to use unstable engines: devnull|ephemeralForTest
+  <%- if @storage_engine -%>
+  engine: <%= @storage_engine %>
+  <% else -%>
+  engine: wiredTiger
+  <% end -%>
+
+  #mmapv1:
+    # Enable or disable the preallocation of data files (true by default)
+    #preallocDataFiles: <boolean>
+
+    # Use a smaller default file size (false by default)
+    #smallFiles: <boolean>
+
+  #wiredTiger:
+    #engineConfig:
+      # The maximum size of the cache that WiredTiger will use for all data
+      # (max(60% of RAM - 1GB, 1GB) by default)
+      #cacheSizeGB: 5
+
+      # The type of compression to use to compress WiredTiger journal data
+      # (none|snappy|zlib, snappy by default)
+      #journalCompressor: <string>
+
+    #collectionConfig:
+      # The default type of compression to use to compress collection data
+      # (none|snappy|zlib, snappy by default)
+      #blockCompressor: <string>
+
+
+# secutiry Options - Authorization and other security settings
+<% if @security_keyfile or @authorization -%>
+security:
+  # Private key for cluster authentication
+  <%- if @security_keyfile -%>
+  keyFile: <%= @security_keyfile %>
+  <%- else -%>
+  #keyFile: <string>
+  <%- end -%>
+
+  # Run with/without security (enabled|disabled, disabled by default)
+  <%- if @authorization -%>
+  authorization: <%= @authorization %>
+  <%- else -%>
+  #authorization
+  <%- end -%>
+<% else -%>
+#security:
+  # Private key for cluster authentication
+  #keyFile: <string>
+
+  # Run with/without security (enabled|disabled, disabled by default)
+  #authorization
+<% end -%>
+
+
+# setParameter Options - Set MongoDB server parameters
+# setParameter:
+
+# opratrionProfiling Options - Profiling settings
+#operationProfiling:
+
+# replication Options - ReplSet settings
+<% if @replication_oplogsizemb or @replication_replsetname -%>
+replication:
+  <%- if @replication_oplogsizemb -%>
+  oplogSizeMB: <%= @replication_oplogsizemb %>
+  <%- end -%>
+  <%- if @replication_replsetname -%>
+  replSetName: <%= @replication_replsetname %>
+  <%- end -%>
+<% else -%>
+#replication:
+<% end -%>
+
+# sharding Options - Shard settings
+#sharding:
+

--- a/templates/mongod-3.4.conf.orig
+++ b/templates/mongod-3.4.conf.orig
@@ -1,0 +1,119 @@
+##
+## For list of options visit:
+## https://docs.mongodb.org/manual/reference/configuration-options/
+##
+
+# systemLog Options - How to do logging
+systemLog:
+  # The default log message verbosity level for components (0-5)
+  verbosity: 0
+
+  # The destination to which MongoDB sends all log output (file|syslog, if not specifed to STDOUT)
+  destination: file
+
+  # Log file to send write to instead of stdout - has to be a file, not directory
+  path: /var/opt/rh/rh-mongodb34/log/mongodb/mongod.log
+
+  # Append to logpath instead of over-writing (false by default)
+  logAppend: true
+
+  # Set the log rotation behavior (rename|reopen, rename by default)
+  logRotate: reopen
+
+
+# processManagement Options - How the process runs
+processManagement:
+  # Fork server process (false by default)
+  fork: true
+
+  # Full path to pidfile (if not set, no pidfile is created)
+  pidFilePath: /var/opt/rh/rh-mongodb34/run/mongodb/mongod.pid
+
+
+# net Options - Network interfaces settings
+net:
+  # Specify port number (27017 by default)
+  port: 27017
+
+  # Comma separated list of ip addresses to listen on (all local ips by default)
+  bindIp: 127.0.0.1,::1
+
+  # Enable IPv6 support (disabled by default)
+  ipv6: true
+
+  unixDomainSocket:
+    # Enable/disable listening on the UNIX domain socket (true by default)
+    enabled: true
+
+    # Alternative directory for UNIX domain sockets (defaults to /tmp)
+    pathPrefix: /var/opt/rh/rh-mongodb34/run/mongodb
+
+  #ssl:
+    # Set the SSL operation mode (disabled|allowSSL|preferSSL|requireSSL)
+    #mode: <string>
+
+    # PEM file for ssl
+    #PEMKeyFile: <string>
+
+    # Certificate Authority file for SSL
+    #CAFile: <string>
+
+
+# storage Options - How and Where to store data
+storage:
+  # Directory for datafiles (defaults to /data/db/)
+  dbPath: /var/opt/rh/rh-mongodb34/lib/mongodb
+
+  #journal:
+    # Enable/Disable journaling (journaling is on by default for 64 bit)
+    #enabled: true
+
+  # The storage engine for the mongod database (mmapv1|wiredTiger, wiredTiger by default
+  # - works for 64 bit only)
+  # Also possible to use unstable engines: devnull|ephemeralForTest
+  engine: wiredTiger
+
+  #mmapv1:
+    # Enable or disable the preallocation of data files (true by default)
+    #preallocDataFiles: <boolean>
+
+    # Use a smaller default file size (false by default)
+    #smallFiles: <boolean>
+
+  #wiredTiger:
+    #engineConfig:
+      # The maximum size of the cache that WiredTiger will use for all data
+      # (max(60% of RAM - 1GB, 1GB) by default)
+      #cacheSizeGB: 5
+
+      # The type of compression to use to compress WiredTiger journal data
+      # (none|snappy|zlib, snappy by default)
+      #journalCompressor: <string>
+
+    #collectionConfig:
+      # The default type of compression to use to compress collection data
+      # (none|snappy|zlib, snappy by default)
+      #blockCompressor: <string>
+
+
+# secutiry Options - Authorization and other security settings
+#security:
+  # Private key for cluster authentication
+  #keyFile: <string>
+
+  # Run with/without security (enabled|disabled, disabled by default)
+  #authorization
+
+
+# setParameter Options - Set MongoDB server parameters
+# setParameter:
+
+# opratrionProfiling Options - Profiling settings
+#operationProfiling:
+
+# replication Options - ReplSet settings
+#replication:
+
+# sharding Options - Shard settings
+#sharding:
+

--- a/templates/mongotools.erb
+++ b/templates/mongotools.erb
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+PROGNAME=$(basename $0)
+RCF="${HOME}/.mongorc.js"
+
+# Parse mongorc file to extract authentication info if possible
+if [ -r ${RCF} ]; then 
+  OLDIFS=$IFS
+  IFS=' '
+  AUTH=($(sed -r -n 's/^(db = connect\(.)(.+):\/\/(.+):(.+)@(.+):(.+)\/(.+)(.\))/\2 \3 \4 \5 \6 \7/ p' ${HOME}/.mongorc.js))
+  IFS=$OLDIFS
+fi
+
+# Extract variable with default value if needed
+PROTO="${AUTH[0]:-mongodb}"
+UNAME="${AUTH[1]:-${USER}}"
+PASS="${AUTH[2]:-}"
+HNAME="${AUTH[3]:-localhost}"
+PORT="${AUTH[4]:-27017}"
+DBNAME="${AUTH[5]:-admin}"
+
+# Prepare wrapping command and execute
+CMD="<% if @scl_name %>scl enable <%= @scl_name %> -- <%= @scl_spath %>/root/usr/bin/<% end %>${PROGNAME}"
+
+exec ${CMD} --host="${HNAME}" --port="${PORT}" --username="${UNAME}" --password="${PASS}" --authenticationDatabase="${DBNAME}" ${*}


### PR DESCRIPTION
This should allow the use of Software Collection (ex: rh-mongo34 and 36) on CentOS and Redhat.
And add support for basic user management (starting with root). Only the creation with initial roles and update of passwords are implemented so far.
For instance, if roles are changed later in Puppet/Hiera, the user will NOT be updated.

In addition, a new template `mongod-2.6.conf` has been added to match current default (as seen on CentOS 7). The legacy template `mongodb-2.6.conf` has not been removed since it could still be explicitly used.

I've only being testing on CentOS 6 and 7. Hopefully, this PR does not break the module on other distros.