### PR TITLE
mongodb : change systemd LimitNPROC default to 48000

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -24,6 +24,7 @@ class mongodb::params (
   case $::operatingsystem {
     'RedHat','CentOS': {
       if versioncmp($::operatingsystemrelease, '7') >= 0 {
+        $m_with_systemd = true
         if versioncmp($mongod_version, '3') >= 0 {
           $conffile = '/etc/mongod.conf'
           $template = "${module_name}/mongod-3.0.conf.erb"


### PR DESCRIPTION
To avoid mongodb limit in this case:
"I CONTROL  [initandlisten] ** WARNING: soft rlimits too low. rlimits set to 31226 processes, 64000 files. Number of processes should be at least 32000 : 0.5 times number of files."

Look like LimitNOFILE=64000 is defined in mongo package, and Mongo recommandation are 64000 for LimitNPROC too (https://docs.mongodb.com/manual/reference/ulimit/).